### PR TITLE
v3.1.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # CRAFT Corpus Changes
 
+## Version 3.1.3
+* Updated file-conversion dependeny to v0.2.2 to handle/prevent some improper discontinuous spans in the coreference annotations. For details, please see this issue: https://github.com/UCDenver-ccp/craft-shared-tasks/issues/1 and the changes made in the file-conversion project: https://github.com/UCDenver-ccp/file-conversion/blob/master/CHANGES.md
+
 ## Version 3.1.2
 * Corrected erroneous extension class prefixes in the `concept-annotation/GO_MF/GO_MF+extensions/GO_MF_stub+GO_MF_extensions.obo` file
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To cite the CRAFT corpus, please see the [CRAFT Reference](https://github.com/UC
 For installation and other usage instructions, please see the [CRAFT Wiki](https://github.com/UCDenver-ccp/CRAFT/wiki).
 
 ### Stable releases
-For stable releases, please download from the [CRAFT Releases](https://github.com/UCDenver-ccp/CRAFT/releases) page. If you are participating in the [CRAFT Shared Task](https://sites.google.com/view/craft-shared-task-2019/home), please download [CRAFT v3.1](https://github.com/UCDenver-ccp/CRAFT/releases/tag/v3.1).
+For stable releases, please download from the [CRAFT Releases](https://github.com/UCDenver-ccp/CRAFT/releases) page. If you are participating in the [CRAFT Shared Task](https://sites.google.com/view/craft-shared-task-2019/home), please download [CRAFT v3.1.3](https://github.com/UCDenver-ccp/CRAFT/releases/tag/v3.1.3).
 
 ### Creating alternative file formats
 The distribution has been streamlined to include only a single file format for each annotation type. In place of multiple file formats for each annotation type, the CRAFT corpus is distributed with a script which can convert annotations from the native file format into a variety of other file formats. Please see the [Creating alternative annotation file formats](https://github.com/UCDenver-ccp/CRAFT/wiki/Alternative-annotation-file-formats) wiki page for details. 

--- a/build.boot
+++ b/build.boot
@@ -1,4 +1,4 @@
-(set-env! :dependencies '[[edu.ucdenver.ccp/file-conversion-onejar "0.2.1"]]
+(set-env! :dependencies '[[edu.ucdenver.ccp/file-conversion-onejar "0.2.2"]]
           :repositories {"bionlp" "https://svn.code.sf.net/p/bionlp/code/repo/"})
 (require '[clojure.java.io :refer [file]]
          '[clojure.java.io :as io])


### PR DESCRIPTION
This PR updates the file-conversion dependency to v0.2.2 to handle/prevent some improper discontinuous spans in the coreference annotations. For details, please see this issue: https://github.com/UCDenver-ccp/craft-shared-tasks/issues/1 and the changes made in the file-conversion project: https://github.com/UCDenver-ccp/file-conversion/blob/master/CHANGES.md