### PR TITLE
correct minor offset errors

### DIFF
--- a/concept-annotation/PR/PR+extensions/knowtator/16121256.txt.knowtator.xml
+++ b/concept-annotation/PR/PR+extensions/knowtator/16121256.txt.knowtator.xml
@@ -1173,7 +1173,7 @@
   <annotation>
     <mention id="PR_reasoned_2017_04_17_backup_Instance_486" />
     <annotator id="PR_reasoned_2017_04_17_Instance_10000">Mike Bada, University of Colorado School of Medicine</annotator>
-    <span start="29483" end="29522" />
+    <span start="29483" end="29521" />
     <spannedText>very long-chain acyl-CoA dehydrogenase</spannedText>
   </annotation>
   <annotation>

--- a/concept-annotation/PR/PR+extensions/knowtator/16700629.txt.knowtator.xml
+++ b/concept-annotation/PR/PR+extensions/knowtator/16700629.txt.knowtator.xml
@@ -1744,8 +1744,7 @@
     <mention id="PR_reasoned_2017_04_17_Instance_202061" />
     <annotator id="PR_reasoned_2017_04_17_Instance_10000">Mike Bada, University of Colorado School of Medicine</annotator>
     <span start="18442" end="18458" />
-    <span start="18442" end="18458" />
-    <spannedText>active caspase-3 ... active caspase-3</spannedText>
+    <spannedText>active caspase-3</spannedText>
   </annotation>
   <annotation>
     <mention id="PR_reasoned_2017_04_17_Instance_202063" />

--- a/concept-annotation/PR/PR/knowtator/16700629.txt.knowtator.xml
+++ b/concept-annotation/PR/PR/knowtator/16700629.txt.knowtator.xml
@@ -1666,8 +1666,7 @@
     <mention id="PR_reasoned_2017_04_17_Instance_202061" />
     <annotator id="PR_reasoned_2017_04_17_Instance_10000">Mike Bada, University of Colorado School of Medicine</annotator>
     <span start="18442" end="18458" />
-    <span start="18442" end="18458" />
-    <spannedText>active caspase-3 ... active caspase-3</spannedText>
+    <spannedText>active caspase-3</spannedText>
   </annotation>
   <annotation>
     <mention id="PR_reasoned_2017_04_17_Instance_202063" />


### PR DESCRIPTION
Tracking down an obscure bug in my code, I found these three minor inconsistencies in the annotations.
All three have the property that the string in the spannedText element doesn't equal the string you get when extracting from the article text using the span offsets.