### PR TITLE
add missing MONDO XML files

### DIFF
--- a/concept-annotation/MONDO/MONDO_with_genotype_annotations/knowtator-2/14723793.xml
+++ b/concept-annotation/MONDO/MONDO_with_genotype_annotations/knowtator-2/14723793.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<knowtator-project>
+    <document id="14723793" text-file="14723793.txt">
+    </document>
+</knowtator-project>

--- a/concept-annotation/MONDO/MONDO_with_genotype_annotations/knowtator-2/16800892.xml
+++ b/concept-annotation/MONDO/MONDO_with_genotype_annotations/knowtator-2/16800892.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<knowtator-project>
+    <document id="16800892" text-file="16800892.txt">
+    </document>
+</knowtator-project>

--- a/concept-annotation/MONDO/MONDO_without_genotype_annotations/knowtator-2/14723793.xml
+++ b/concept-annotation/MONDO/MONDO_without_genotype_annotations/knowtator-2/14723793.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<knowtator-project>
+    <document id="14723793" text-file="14723793.txt">
+    </document>
+</knowtator-project>

--- a/concept-annotation/MONDO/MONDO_without_genotype_annotations/knowtator-2/16800892.xml
+++ b/concept-annotation/MONDO/MONDO_without_genotype_annotations/knowtator-2/16800892.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<knowtator-project>
+    <document id="16800892" text-file="16800892.txt">
+    </document>
+</knowtator-project>


### PR DESCRIPTION
There are two documents in CRAFT that do not contain any MONDO class mentions. Previously there were not Knowtator2 XML files for these documents which were expected to exist by the boot script. This was causing errors in using the MONDO annotations. Knowtator2 XML files for PMIDs 14723793 and 16800892 have been added to both the MONDO_with_genotype_annotations/ and MONDO_without_geneotype_annotations/ directories.

Addresses Issue #21